### PR TITLE
Fix application layout generation

### DIFF
--- a/src/cli.cr
+++ b/src/cli.cr
@@ -56,10 +56,14 @@ module Frost
         File.chmod(mode, File.join(path, *path_names))
       end
 
-      macro template(template_name, path)
-        contents = String.build do |__buf__|
-          embed_ecr {{ "#{ TEMPLATES_PATH.id }/#{ template_name.id }.ecr" }}, "__buf__"
-        end
+      macro template(template_name, path, render = true)
+        {% if render %}
+          contents = String.build do |__buf__|
+            embed_ecr {{ "#{ TEMPLATES_PATH.id }/#{ template_name.id }.ecr" }}, "__buf__"
+          end
+        {% else %}
+          contents = File.read({{ "#{ TEMPLATES_PATH.id }/#{ template_name.id }.ecr" }})
+        {% end %}
 
         if File.exists?(File.join(path, {{ path }}))
           if File.read(File.join(path, {{ path }})).strip == contents.strip
@@ -147,7 +151,8 @@ module Frost
         mkdir "app", "views"
         template "application_view", File.join("app", "views", "application_view.cr")
         template "layouts_view", File.join("app", "views", "layouts_view.cr")
-        template "layout", File.join("app", "views", "layouts/application.html.ecr")
+        mkdir "app", "views", "layouts"
+        template "layout", File.join("app", "views", "layouts/application.html.ecr"), false
       end
 
       def generate_public

--- a/src/generators/application/main.ecr
+++ b/src/generators/application/main.ecr
@@ -3,6 +3,7 @@ require "frost/server/handlers/log_handler"
 require "frost/server/handlers/public_file_handler"
 require "frost/server/handlers/deflate_handler"
 require "frost/server/handlers/https_everywhere_handler"
+require "option_parser"
 require "./config/bootstrap"
 
 host = "localhost"


### PR DESCRIPTION
Hi,

Currently the project generation is broken due to missing application layout directory and broken layout template.

Since I don't know if it is an option to escape ecr tags (I filled an [issue](https://github.com/manastech/crystal/issues/1999) on crystal repo), I added an option to skip template rendering and just copy the file to the new project directory.

I know that right now it is a hack, since it doesn't support custom layout file ( If you want to add a custom `<title>` tag for example), but it fixes the new project command.
