### PR TITLE
README: Correct CONTRIBUTING link

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ until a new Frost release is made.
 ## Contribute
 
 Thanks for considering to contribute! Please see
-[CONTRIBUTES](https://github.com/ysbaddaden/frost/blob/master/CONTRIBUTES.md)
+[CONTRIBUTING](https://github.com/ysbaddaden/frost/blob/master/CONTRIBUTING.md)
 to get started.
 
 


### PR DESCRIPTION
README was linking to a file that didn't exist in the repository (`CONTRIBUTES.md`)

This change corrects it and links to the existing file: `CONTRIBUTING.md` instead.

Cheers!
:heart: :heart: :heart: 
