### PR TITLE
add type to app_path

### DIFF
--- a/src/cli.cr
+++ b/src/cli.cr
@@ -93,6 +93,8 @@ module Frost
       include ShellActions
       getter :name, :app_path, :templates_path
 
+      @app_path : String
+
       def initialize(@app_path)
         @name = File.basename(app_path)
       end


### PR DESCRIPTION
It's corresponse for Crystal version 0.23.

A problem occurred in this procedure.
```
crystal frost/src/cli.cr -- new myapp

in frost/src/cli.cr:96: Can't infer the type of instance variable '@app_path' of Frost::Commands::ApplicationGenerator
```
